### PR TITLE
build the full dataset lazily while mining

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,9 @@ pub struct Opt {
     #[clap(long = "no-full-dataset", display_order = 12)]
     /// Disable full dataset prebuilding (~4.6GB). Uses light cache only (~75MB). [default: false]
     pub no_full_dataset: bool,
+    #[clap(long = "lazy-dataset", display_order = 13)]
+    /// Lazily build the dataset on demand. Pre-allocates 4.6GB but only computes items when accessed. Requires --no-full-dataset to be false. [default: false]
+    pub lazy_dataset: bool,
 }
 
 fn parse_devfund_percent(s: &str) -> Result<u16, &'static str> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,7 @@ async fn main() -> Result<(), Error> {
                     shutdown.clone(),
                     opt.mine_when_not_synced,
                     !opt.no_full_dataset,
+                    opt.lazy_dataset,
                 );
                 if let Some(devfund_address) = &opt.devfund_address {
                     client.add_devfund(devfund_address.clone(), opt.devfund_percent);

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -55,8 +55,9 @@ impl MinerManager {
         shutdown: ShutdownHandler,
         mine_when_not_synced: bool,
         use_full_dataset: bool,
+        lazy_dataset: bool,
     ) -> Self {
-        let context = Arc::new(Mutex::new(FishHashContext::new(use_full_dataset, None)));
+        let context = Arc::new(Mutex::new(FishHashContext::new(use_full_dataset, lazy_dataset, None)));
         let hashes_tried = Arc::new(AtomicU64::new(0));
         let watch = WatchSwap::empty();
         let handles = Self::launch_cpu_threads(
@@ -157,7 +158,7 @@ impl MinerManager {
                 };
                 state_ref.nonce = nonce.0;
 
-                if let Some(block) = state_ref.generate_block_if_pow(&mut *context.lock().unwrap()) {
+                if let Some(block) = state_ref.generate_block_if_pow(&mut context.lock().unwrap()) {
                     found_block(&send_channel, block)?;
                 }
                 nonce += Wrapping(1);

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -37,7 +37,7 @@ impl State {
 
     #[inline(always)]
     /// PRE_POW_HASH || TIME || 32 zero byte padding || NONCE
-    pub fn calculate_khashv2(&self, context: &FishHashContext) -> Uint256 {
+    pub fn calculate_khashv2(&self, context: &mut FishHashContext) -> Uint256 {
         // Hasher already contains PRE_POW_HASH || TIME || 32 zero byte padding; so only the NONCE is missing
         let hash = self.hasher.clone().finalize_with_nonce(self.nonce);
         // println!("hash-1 : {:?}", hash);
@@ -51,7 +51,7 @@ impl State {
 
     #[inline(always)]
     /// PRE_POW_HASH || TIME || 32 zero byte padding || NONCE
-    pub fn calculate_pow(&self, context: &FishHashContext) -> Uint256 {
+    pub fn calculate_pow(&self, context: &mut FishHashContext) -> Uint256 {
         match self.header_version {
             2 => self.calculate_khashv2(context),
             _ => unreachable!(
@@ -62,14 +62,14 @@ impl State {
     }
 
     #[inline(always)]
-    pub fn check_pow(&self, context: &FishHashContext) -> bool {
+    pub fn check_pow(&self, context: &mut FishHashContext) -> bool {
         let pow = self.calculate_pow(context);
         // The pow hash must be less or equal than the claimed target.
         pow <= self.target
     }
 
     #[inline(always)]
-    pub fn generate_block_if_pow(&self, context: &FishHashContext) -> Option<RpcBlock> {
+    pub fn generate_block_if_pow(&self, context: &mut FishHashContext) -> Option<RpcBlock> {
         self.check_pow(context).then(|| {
             let mut block = self.block.clone();
             let header = block.header.as_mut().expect("We checked that a header exists on creation");


### PR DESCRIPTION
pre-allocates `Vec<Hash1024>` with zeros and then in lookup if item == 0 (to check if the item was computed or not) we compute the item and store the result, so next time the same index needs to be accessed we already have it and can skip the computation